### PR TITLE
Include full-name

### DIFF
--- a/xentop.go
+++ b/xentop.go
@@ -100,7 +100,7 @@ func parseLine(line string, header []string) (map[string]string, error) {
 }
 
 func XenTopCmd(lines chan<- Line, errs chan<- error, cmdPath string) {
-	cmd := exec.Command(cmdPath, "-b")
+	cmd := exec.Command(cmdPath, "-b -f")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/xentop.go
+++ b/xentop.go
@@ -100,7 +100,7 @@ func parseLine(line string, header []string) (map[string]string, error) {
 }
 
 func XenTopCmd(lines chan<- Line, errs chan<- error, cmdPath string) {
-	cmd := exec.Command(cmdPath, "-b -f")
+	cmd := exec.Command(cmdPath, "-b", "-f")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Add the -f parameter to xentop so that the full-name of the Xen is included, rather than just a truncated name.